### PR TITLE
Libalpm13 fixups

### DIFF
--- a/completion/zsh.patch
+++ b/completion/zsh.patch
@@ -1,7 +1,7 @@
 --- a/zsh
 +++ b/zsh
 @@ -1,1 +1,1 @@
--#compdef pacman pacman.static=pacman pacman-key makepkg
+-#compdef pacman pacman.static=pacman pacman-conf pacman-key makepkg
 +#compdef pakku
 @@ -139,2 +139,6 @@
  	'--print-format[Specify how the targets should be printed]'
@@ -27,24 +27,3 @@
 @@ -361,1 +370,1 @@
 -	cmd=( "pacman" "2>/dev/null")
 +	cmd=("pakku" "2>/dev/null")
-@@ -371,1 +380,1 @@
--_pakku_zsh_comp() {
-+_pakku_comp() {
-@@ -501,17 +510,0 @@
--
--_pakku_comp() {
--	case "$service" in
--		makepkg)
--			_makepkg "$@"
--			;;
--		pacman-key)
--			_pakku_key "$@"
--			;;
--		pacman)
--			_pakku_zsh_comp "$@"
--			;;
--		*)
--			_message "Error"
--			;;
--	esac
--}

--- a/completion/zsh.patch
+++ b/completion/zsh.patch
@@ -27,3 +27,27 @@
 @@ -361,1 +370,1 @@
 -	cmd=( "pacman" "2>/dev/null")
 +	cmd=("pakku" "2>/dev/null")
+@@ -371,1 +380,1 @@
+-_pakku_zsh_comp() {
++_pakku_comp() {
+@@ -596,20 +616,0 @@
+-
+-_pakku_comp() {
+-	case "$service" in
+-		makepkg)
+-			_makepkg "$@"
+-			;;
+-		pacman-conf)
+-			_pakku_conf "$@"
+-			;;
+-		pacman-key)
+-			_pakku_key "$@"
+-			;;
+-		pacman)
+-			_pakku_zsh_comp "$@"
+-			;;
+-		*)
+-			_message "Error"
+-			;;
+-	esac
+-}

--- a/src/wrapper/alpm.nim
+++ b/src/wrapper/alpm.nim
@@ -43,8 +43,8 @@ proc newAlpmHandle*(root: cstring, dbpath: cstring, err: var cint): ptr AlpmHand
 proc release*(handle: ptr AlpmHandle): cint
   {.cdecl, importc: "alpm_release".}
 
-proc setArch*(handle: ptr AlpmHandle, arch: cstring): cint
-  {.cdecl, importc: "alpm_option_set_arch".}
+proc addArch*(handle: ptr AlpmHandle, arch: cstring): cint
+  {.cdecl, importc: "alpm_option_add_architecture".}
 
 proc vercmp*(a: cstring, b: cstring): cint
   {.cdecl, importc: "alpm_pkg_vercmp".}
@@ -137,7 +137,7 @@ template withAlpm*(root: string, db: string, dbs: seq[string], arch: string,
           .replace("%s", "$#") % [dbName, $handle.errno.errorAlpm]
 
     try:
-      discard handle.setArch(arch)
+      discard handle.addArch(arch)
       body
     finally:
       discard handle.release()


### PR DESCRIPTION
some things were stopping it from compiling with the new version of libalpm, heres my attempt at fixing them.
from what I can tell `alpm_option_add_architecture` matches the now removed `alpm_option_set_arch`, the signature is the same and it seems to work for what its worth at least.

the zsh completion patch had some issues and seemingly broken parts that broke it as well so I also fixed that up.