### PR TITLE
Initial doas support

### DIFF
--- a/doc/pakku.conf.5.txt
+++ b/doc/pakku.conf.5.txt
@@ -65,6 +65,11 @@ Options
 	This command will be executed in package directory before building,
 	allowing you to modify PKGBUILD or perform other necessary actions.
 
+*PreferredSudoCommand =* command::
+	This is the command that will be used to escalate priviliges. If the option is
+	not set or the command is not found on the system, pakku will try to guess the
+	command between sudo, doas and su.
+
 See Also
 --------
 linkman:pacman.conf[5], linkman:pakku[8]

--- a/pakku.conf
+++ b/pakku.conf
@@ -16,3 +16,4 @@ PrintLocalIsNewer
 #PreserveBuilt = Disabled
 
 #PreBuildCommand =
+#PreferredSudoCommand =

--- a/src/common.nim
+++ b/src/common.nim
@@ -48,12 +48,13 @@ var isArtix*: bool
 var isArch*: bool
 var isParabola*: bool
 
-proc checkAndRefreshUpgradeInternal(color: bool, upgrade: bool, args: seq[Argument]):
-  tuple[code: int, args: seq[Argument]] =
+proc checkAndRefreshUpgradeInternal(
+  sudoPrefix: seq[string], color: bool, upgrade: bool, args: seq[Argument]
+  ): tuple[code: int, args: seq[Argument]] =
   let refreshCount = args.count(%%%"refresh")
   let upgradeCount = if upgrade: args.count(%%%"sysupgrade") else: 0
   if refreshCount > 0 or upgradeCount > 0:
-    let code = pacmanRun(true, color, args
+    let code = pacmanRun(some sudoPrefix, color, args
       .keepOnlyOptions(commonOptions, transactionOptions, upgradeOptions) &
       ("S", none(string), ArgumentType.short) &
       ("y", none(string), ArgumentType.short).repeat(refreshCount) &
@@ -66,13 +67,13 @@ proc checkAndRefreshUpgradeInternal(color: bool, upgrade: bool, args: seq[Argume
   else:
     (0, args)
 
-template checkAndRefreshUpgrade*(color: bool, args: seq[Argument]):
+template checkAndRefreshUpgrade*(sudoPrefix: seq[string], color: bool, args: seq[Argument]):
   tuple[code: int, args: seq[Argument]] =
-  checkAndRefreshUpgradeInternal(color, true, args)
+  checkAndRefreshUpgradeInternal(sudoPrefix, color, true, args)
 
-template checkAndRefresh*(color: bool, args: seq[Argument]):
+template checkAndRefresh*(sudoPrefix: seq[string], color: bool, args: seq[Argument]):
   tuple[code: int, args: seq[Argument]] =
-  checkAndRefreshUpgradeInternal(color, false, args)
+  checkAndRefreshUpgradeInternal(sudoPrefix, color, false, args)
 
 proc noconfirm*(args: seq[Argument]): bool =
   args

--- a/src/config.nim
+++ b/src/config.nim
@@ -1,5 +1,5 @@
 import
-  options, posix, re, sequtils, sets, strutils, sugar, tables,
+  std/[options, posix, re, sequtils, sets, strutils, sugar, tables],
   utils
 
 type
@@ -56,7 +56,8 @@ type
     sudoExec: bool,
     viewNoDefault: bool,
     preserveBuilt: PreserveBuilt,
-    preBuildCommand: Option[string]
+    preBuildCommand: Option[string],
+    sudoCommand: seq[string]
   ]
 
 proc readConfigFile*(configFile: string):
@@ -160,23 +161,27 @@ proc obtainConfig*(config: PacmanConfig): Config =
   proc obtainTmpDir(user: User): string =
     options.opt("TmpDir").get("/tmp/pakku-${USER}").handleDirPattern(user)
 
-  let initialOrCurrentUser = initialUser.get(currentUser)
-  let userCacheInitial = obtainUserCacheDir(initialOrCurrentUser)
-  let userCacheCurrent = obtainUserCacheDir(currentUser)
-  let tmpRootInitial = obtainTmpDir(initialOrCurrentUser)
-  let tmpRootCurrent = obtainTmpDir(currentUser)
-  let aurRepo = options.opt("AurRepo").get("aur")
-  let aurComments = options.hasKey("AurComments")
-  let checkIgnored = options.hasKey("CheckIgnored")
-  let ignoreArch = options.hasKey("IgnoreArch")
-  let printAurNotFound = options.hasKey("PrintAurNotFound")
-  let printLocalIsNewer = options.hasKey("PrintLocalIsNewer")
-  let sudoExec = options.hasKey("SudoExec")
-  let viewNoDefault = options.hasKey("ViewNoDefault")
-  let preserveBuilt = toSeq(enumerate[PreserveBuilt]())
-    .filter(o => some($o) == options.opt("PreserveBuilt"))
-    .optLast.get(PreserveBuilt.disabled)
-  let preBuildCommand = options.opt("PreBuildCommand")
+  let
+    initialOrCurrentUser = initialUser.get(currentUser)
+    userCacheInitial = obtainUserCacheDir(initialOrCurrentUser)
+    userCacheCurrent = obtainUserCacheDir(currentUser)
+    tmpRootInitial = obtainTmpDir(initialOrCurrentUser)
+    tmpRootCurrent = obtainTmpDir(currentUser)
+    aurRepo = options.opt("AurRepo").get("aur")
+    aurComments = options.hasKey("AurComments")
+    checkIgnored = options.hasKey("CheckIgnored")
+    ignoreArch = options.hasKey("IgnoreArch")
+    printAurNotFound = options.hasKey("PrintAurNotFound")
+    printLocalIsNewer = options.hasKey("PrintLocalIsNewer")
+    sudoExec = options.hasKey("SudoExec")
+    viewNoDefault = options.hasKey("ViewNoDefault")
+    preserveBuilt = toSeq(enumerate[PreserveBuilt]())
+      .filter(o => some($o) == options.opt("PreserveBuilt"))
+      .optLast.get(PreserveBuilt.disabled)
+    preBuildCommand = options.opt("PreBuildCommand")
+    sudoCommand = options.opt("SudoCommand")
+      .map(it => it.splitWhitespace())
+      .get(defaultSudoPrefix)
 
   if config.common.dbs.find(aurRepo) >= 0:
     raise commandError(tr"repo '$#' can not be used as fake AUR repository" % [aurRepo],
@@ -192,7 +197,7 @@ proc obtainConfig*(config: PacmanConfig): Config =
     config.common.ignorePkgs, config.common.ignoreGroups),
     root, db, cache, userCacheInitial, userCacheCurrent, tmpRootInitial, tmpRootCurrent,
     color, aurRepo, aurComments, checkIgnored, ignoreArch, printAurNotFound, printLocalIsNewer,
-    sudoExec, viewNoDefault, preserveBuilt, preBuildCommand)
+    sudoExec, viewNoDefault, preserveBuilt, preBuildCommand, sudoCommand)
 
 template withAlpmConfig*(config: Config, passDbs: bool,
   handle: untyped, alpmDbs: untyped, errors: untyped, body: untyped): untyped =

--- a/src/config.nim
+++ b/src/config.nim
@@ -179,9 +179,7 @@ proc obtainConfig*(config: PacmanConfig): Config =
       .filter(o => some($o) == options.opt("PreserveBuilt"))
       .optLast.get(PreserveBuilt.disabled)
     preBuildCommand = options.opt("PreBuildCommand")
-    sudoCommand = options.opt("SudoCommand")
-      .map(it => it.splitWhitespace())
-      .get(defaultSudoPrefix)
+    sudoCommand = options.opt("PreferredSudoCommand").getSudoPrefix()
 
   if config.common.dbs.find(aurRepo) >= 0:
     raise commandError(tr"repo '$#' can not be used as fake AUR repository" % [aurRepo],

--- a/src/feature/localquery.nim
+++ b/src/feature/localquery.nim
@@ -34,7 +34,7 @@ proc handleQueryOrphans*(args: seq[Argument], config: Config): int =
       not arg.matchOption(%%%"unrequired") and
       not arg.matchOption(%%%"deps")) &
       results.map(r => (r, none(string), ArgumentType.target))
-    pacmanExec(false, config.color, newArgs)
+    pacmanExec(noPrefix, config.color, newArgs)
   elif targets.len == 0:
     0
   else:

--- a/src/feature/syncclean.nim
+++ b/src/feature/syncclean.nim
@@ -4,7 +4,7 @@ import
   "../wrapper/alpm"
 
 proc handleSyncClean*(args: seq[Argument], config: Config): int =
-  let code = pacmanRun(true, config.color, args)
+  let code = pacmanRun(some config.sudoCommand, config.color, args)
   if code != 0:
     code
   else:

--- a/src/feature/syncinfo.nim
+++ b/src/feature/syncinfo.nim
@@ -88,20 +88,20 @@ proc handleTarget(config: Config, padding: int, args: seq[Argument],
       0
     elif full.sync.target.reference.constraint.isSome:
       # pacman doesn't support constraints for --info queries
-      pacmanRun(false, config.color, args & full.sync.foundInfos.map(i =>
+      pacmanRun(noPrefix, config.color, args & full.sync.foundInfos.map(i =>
         (i.repo & "/" & full.sync.target.reference.name, none(string), ArgumentType.target)))
     else:
-      pacmanRun(false, config.color, args &
+      pacmanRun(noPrefix, config.color, args &
         ($full.sync.target, none(string), ArgumentType.target))
   else:
     if full.sync.target.repo == some(config.aurRepo):
       printError(config.color, trp("package '%s' was not found\n") % [$full.sync.target])
       1
     else:
-      pacmanRun(false, config.color, args & ($full.sync.target, none(string), ArgumentType.target))
+      pacmanRun(noPrefix, config.color, args & ($full.sync.target, none(string), ArgumentType.target))
 
 proc handleSyncInfo*(args: seq[Argument], config: Config): int =
-  let (refreshCode, callArgs) = checkAndRefresh(config.color, args)
+  let (refreshCode, callArgs) = checkAndRefresh(config.sudoCommand, config.color, args)
   if refreshCode != 0:
     refreshCode
   else:
@@ -122,9 +122,9 @@ proc handleSyncInfo*(args: seq[Argument], config: Config): int =
       f.sync.target.repo == some(config.aurRepo) or
       f.sync.target.reference.constraint.isSome).len == 0:
       if code == 0:
-        pacmanExec(false, config.color, callArgs)
+        pacmanExec(noPrefix, config.color, callArgs)
       else:
-        discard pacmanRun(false, config.color, callArgs)
+        discard pacmanRun(noPrefix, config.color, callArgs)
         code
     else:
       let finalArgs = callArgs.filter(arg => not arg.isTarget)

--- a/src/feature/syncsearch.nim
+++ b/src/feature/syncsearch.nim
@@ -5,7 +5,7 @@ import
   "../wrapper/alpm"
 
 proc handleSyncSearch*(args: seq[Argument], config: Config): int =
-  let (refreshCode, callArgs) = checkAndRefresh(config.color, args)
+  let (refreshCode, callArgs) = checkAndRefresh(config.sudoCommand, config.color, args)
   if refreshCode != 0:
     refreshCode
   else:
@@ -39,12 +39,12 @@ proc handleSyncSearch*(args: seq[Argument], config: Config): int =
     var code = min(aerrors.len, 1)
     if pkgs.len == 0:
       if code == 0:
-        pacmanExec(false, config.color, callArgs)
+        pacmanExec(noPrefix, config.color, callArgs)
       else:
-        discard pacmanRun(false, config.color, callArgs)
+        discard pacmanRun(noPrefix, config.color, callArgs)
         code
     else:
-      discard pacmanRun(false, config.color, callArgs)
+      discard pacmanRun(noPrefix, config.color, callArgs)
 
       for pkg in pkgs:
         if quiet:

--- a/src/feature/syncsource.nim
+++ b/src/feature/syncsource.nim
@@ -161,7 +161,7 @@ proc cloneAndCopy(config: Config, quiet: bool, fullTargets: seq[FullPackageTarge
     0
 
 proc handleSyncSource*(args: seq[Argument], config: Config): int =
-  let (refreshCode, _) = checkAndRefresh(config.color, args)
+  let (refreshCode, _) = checkAndRefresh(config.sudoCommand, config.color, args)
   if refreshCode != 0:
     refreshCode
   else:


### PR DESCRIPTION
`doas` seems almost a drop in replacement for `sudo`, so automatic
support was hardcoded.

Other changes are more in line with supporting an arbitrary command to use for
root execution, to use something other than `doas` or some custom
command.

More detailed changes are:

* Added `doas` to `defaultSudoPrefix` search for automatic detecting.
* Added a `sudoCommand` option to Pakku configuration file
* Replaces `useRoot` flag with an `Option[seq[string]]` parameter
* Added a `prefix` param to all procs that used the global `defaultSudoPrefix`