### PR TITLE
build: move compiler settings into config.nims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 VERSION = 0.16
-COPYRIGHT = 2018-2019 kitsunyan
 DIST_MODE = false
 
 MAN_PAGES = \
@@ -19,6 +18,7 @@ TARGETS_NODIST = \
 DIST = \
 	COPYING \
 	Makefile \
+	config.nims \
 	pakku.conf \
 	completion/bash.patch \
 	completion/bash-git.patch \
@@ -50,23 +50,11 @@ else
 RVERSION = ${VERSION}
 endif
 
-NIM_TARGET = release
-NIM_OPTIMIZE = size
 NIM_CACHE_DIR = nimcache
 
 NIM_OPTIONS = \
-	--putenv:'PROG_VERSION'="${RVERSION}" \
-	--putenv:'PROG_COPYRIGHT'="${COPYRIGHT}" \
-	--putenv:'PROG_PKGLIBDIR'="${PKGLIBDIR}" \
-	--putenv:'PROG_LOCALSTATEDIR'="${LOCALSTATEDIR}" \
-	--putenv:'PROG_SYSCONFDIR'="${SYSCONFDIR}" \
-	-d:'${NIM_TARGET}' \
-#	-d:nimPreviewSlimSystem \
-	--opt:'${NIM_OPTIMIZE}' \
-	--hint'[Conf]':off \
-	--hint'[Processing]':off \
-	--hint'[Link]':off \
-	--hint'[SuccessX]':off
+	-d:pakkuVersion="${RVERSION}" \
+	-d:pakkuPrefix="${PREFIX}"
 
 ASCIIDOC_OPTIONS = \
 	-f doc/asciidoc.conf \

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,14 @@ completion/bash: \
 	completion/bash.patch \
 	completion/bash-git.patch
 	@echo "GEN: $@"
-	@(cd completion && ./make.sh 'bash')
+	@(cd completion && /bin/bash ./make.sh 'bash')
 
 completion/zsh: \
 	completion/make.sh \
 	completion/zsh.patch \
 	completion/zsh-git.patch
 	@echo "GEN: $@"
-	@(cd completion && ./make.sh 'zsh')
+	@(cd completion && /bin/bash ./make.sh 'zsh')
 
 ${MAN_PAGES:=.in}: ${MAN_PAGES:=.txt}
 	@echo "GEN: $@"
@@ -118,39 +118,39 @@ ifneq (${DIST_MODE},true)
 endif
 
 define install
-	@echo 'INSTALL: $3'
-	@install -Dm$1 $2 '${DESTDIR}$3'
+	@echo "INSTALL: ${DESTDIR}$3"
+	@install -Dm$1 $2 "${DESTDIR}$3"
 endef
 
 define uninstall
-	@echo 'UNINSTALL: $1/$2'
-	@rm '${DESTDIR}$1/$2'
-	@rmdir -p '${DESTDIR}$1' 2> /dev/null || true
+	@echo "UNINSTALL: ${DESTDIR}$1/$2"
+	@rm "${DESTDIR}$1/$2"
+	@rmdir -p "${DESTDIR}$1" 2> /dev/null || true
 endef
 
 install:
-	$(call install,644,'completion/bash','${BASHCOMPLETIONSDIR}/pakku')
-	$(call install,644,'completion/zsh','${ZSHCOMPLETIONSDIR}/_pakku')
-	$(call install,644,'doc/pakku.8','${MANDIR}/man8/pakku.8')
-	$(call install,644,'doc/pakku.conf.5','${MANDIR}/man5/pakku.conf.5')
-	$(call install,755,'lib/tools','${PKGLIBDIR}/tools')
-	@echo 'INSTALL: ${PKGLIBDIR}/bisect'
+	$(call install,644,completion/bash,${BASHCOMPLETIONSDIR}/pakku)
+	$(call install,644,completion/zsh,${ZSHCOMPLETIONSDIR}/_pakku)
+	$(call install,644,doc/pakku.8,${MANDIR}/man8/pakku.8)
+	$(call install,644,doc/pakku.conf.5,${MANDIR}/man5/pakku.conf.5)
+	$(call install,755,lib/tools,${PKGLIBDIR}/tools)
+	@echo "INSTALL: ${DESTDIR}${PKGLIBDIR}/bisect"
 	@ln -s tools ${DESTDIR}${PKGLIBDIR}/bisect
-	@echo 'INSTALL: ${PKGLIBDIR}/install'
+	@echo "INSTALL: ${DESTDIR}${PKGLIBDIR}/install"
 	@ln -s tools ${DESTDIR}${PKGLIBDIR}/install
-	$(call install,755,'src/pakku','${BINDIR}/pakku')
-	$(call install,644,'pakku.conf','${SYSCONFDIR}/pakku.conf')
+	$(call install,755,src/pakku,${BINDIR}/pakku)
+	$(call install,644,pakku.conf,${SYSCONFDIR}/pakku.conf)
 
 uninstall:
-	$(call uninstall,'${BASHCOMPLETIONSDIR}','pakku')
-	$(call uninstall,'${ZSHCOMPLETIONSDIR}','_pakku')
-	$(call uninstall,'${MANDIR}/man8','pakku.8')
-	$(call uninstall,'${MANDIR}/man5','pakku.conf.5')
-	$(call uninstall,'${PKGLIBDIR}','tools')
-	$(call uninstall,'${PKGLIBDIR}','bisect')
-	$(call uninstall,'${PKGLIBDIR}','install')
-	$(call uninstall,'${BINDIR}','pakku')
-	$(call uninstall,'${SYSCONFDIR}','pakku.conf')
+	$(call uninstall,${BASHCOMPLETIONSDIR},pakku)
+	$(call uninstall,${ZSHCOMPLETIONSDIR},_pakku)
+	$(call uninstall,${MANDIR}/man8,pakku.8)
+	$(call uninstall,${MANDIR}/man5,pakku.conf.5)
+	$(call uninstall,${PKGLIBDIR},tools)
+	$(call uninstall,${PKGLIBDIR},bisect)
+	$(call uninstall,${PKGLIBDIR},install)
+	$(call uninstall,${BINDIR},pakku)
+	$(call uninstall,${SYSCONFDIR},pakku.conf)
 
 distcheck:
 	@rm -rf 'pakku-${RVERSION}'

--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,47 @@
+const
+  Version       = "0.16-dev"
+  Prefix        = "/usr/local"
+  SysConfDir    = "/etc"
+  LocalStateDir = "/var"
+  BuildTarget   = "release"
+  BuildOptimize = "size"
+  Copyright     = """2018-2019 kitsunyan
+2020-2023 zqqw"""
+
+switch("define", "pakkuVersion=" & Version)
+switch("define", "pakkuPrefix=" & Prefix)
+switch("define", "SysConfDir=" & SysConfDir)
+switch("define", "LocalStateDir=" & LocalStateDir)
+switch("define", "pakkuCopyright=" & Copyright)
+
+--mm:arc
+--threads:off
+--define:buildTarget
+#--define:nimPreviewSlimSystem
+
+when defined(release):
+  switch("opt", BuildOptimize)
+  --passL:"-s"
+  --passC:"-s"
+  --passL:"-flto"
+  --passC:"-flto"
+  --hint:"[Conf]:off"
+  --hint:"[Processing]:off"
+  --hint:"[Link]:off"
+  --hint:"[SuccessX]:off"
+
+import std/strutils
+
+task build, "development debug build":
+  # propagates custom args
+  let nargs = paramCount()
+  var extra = newSeq[string]()
+  if nargs > 2: # other than `nim build`
+    var skippedTask = false
+    for i in 1..nargs:
+      let arg = paramStr(i)
+      if not skippedTask and arg == "build":
+        skippedTask = true
+        continue
+      extra.add arg
+  selfExec("c " & extra.join(" ") & " -o:pakku src/main.nim")

--- a/config.nims
+++ b/config.nims
@@ -30,13 +30,13 @@ when defined(release):
   --hint:"[Link]:off"
   --hint:"[SuccessX]:off"
 
-import std/strutils
+import std/[os, strutils]
 
 task build, "development debug build":
   # propagates custom args
   let nargs = paramCount()
   var extra = newSeq[string]()
-  if nargs > 2: # other than `nim build`
+  if nargs > 1:
     var skippedTask = false
     for i in 1..nargs:
       let arg = paramStr(i)
@@ -45,3 +45,20 @@ task build, "development debug build":
         continue
       extra.add arg
   selfExec("c " & extra.join(" ") & " -o:pakku src/main.nim")
+
+task testmakefile, "run Makefile smoke tests":
+  let destdir = getTempDir() / "pakku-makefile-test"
+  let overriddenPrefix = "/usr"
+  let pakkuBin = destdir / overriddenPrefix.strip(chars = {'/'}) / "bin" / "pakku"
+  if dirExists(destdir): rmDir(destdir)
+  for cmd in [
+    "make clean",
+    "make",
+    "make PREFIX='" & overriddenPrefix & "' src/pakku",
+    "make PREFIX='" & overriddenPrefix & "' DESTDIR='" & destdir & "' install",
+    "'" & pakkuBin & "' -V",
+    "make PREFIX='" & overriddenPrefix & "' DESTDIR='" & destdir & "' uninstall",
+  ]:
+    exec cmd
+  if dirExists(destdir):
+    quit "DESTDIR still exists after uninstall: " & destdir

--- a/src/common.nim
+++ b/src/common.nim
@@ -416,6 +416,7 @@ proc bisectVersion(repoPath: string, debug: bool, firstCommit: Option[string],
       realLastThreeCommits[0 .. index]
     else:
       realLastThreeCommits
+  let bisectCommand = helperToolCommand("bisect")
 
   proc checkCommit(commit: string): Option[string] =
     let checkout1Code = forkExecWithoutOutput(gitCmd, "-C", repoPath,
@@ -426,8 +427,7 @@ proc bisectVersion(repoPath: string, debug: bool, firstCommit: Option[string],
     else:
       let foundVersion = forkWaitRedirect(() => (block:
         if not dropPrivileges or dropPrivRedirect():
-          execRedirect(pkgLibDir & "/bisect",
-            compareMethod, repoPath & "/" & gitSubdir, version)
+          execRedirect(bisectCommand & @[compareMethod, repoPath / gitSubdir, version])
         else:
           quit(1)))
         .output.optFirst
@@ -465,8 +465,13 @@ proc bisectVersion(repoPath: string, debug: bool, firstCommit: Option[string],
     if bisectStartCode != 0:
       none(string)
     else:
-      discard forkExecWithoutOutput(gitCmd, "-C", repoPath,
-        "bisect", "run", pkgLibDir & "/bisect", compareMethod, gitSubdir, version)
+      if bisectCommand.len == 1:
+        discard forkExecWithoutOutput(gitCmd, "-C", repoPath,
+          "bisect", "run", bisectCommand[0], compareMethod, gitSubdir, version)
+      else:
+        discard forkExecWithoutOutput(gitCmd, "-C", repoPath,
+          "bisect", "run", bisectCommand[0], bisectCommand[1],
+          compareMethod, gitSubdir, version)
 
       let commit = forkWaitRedirect(() => (block:
         if not dropPrivileges or dropPrivRedirect():
@@ -584,6 +589,8 @@ proc findVersion(repoPath: string, debug: bool, version: string,
       else:
         quit(1)))
 
+  let bisectCommand = helperToolCommand("bisect")
+
 # find commit containing correct version using git log grep on commit messages
 
   var commandOutput: tuple[output: seq[string], code: int]
@@ -597,7 +604,7 @@ proc findVersion(repoPath: string, debug: bool, version: string,
     if forkExecWithoutOutput(gitCmd, "-C", repoPath, "checkout", commandOutput.output[i]) == 0:
       let foundVersion = forkWaitRedirect(() => (block:
         if not dropPrivileges or dropPrivRedirect():
-          execRedirect(pkgLibDir & "/bisect", "source", repoPath & "/trunk", version, "true")
+          execRedirect(bisectCommand & @["source", repoPath / "trunk", version, "true"])
         else:
           quit(1)))
       if foundVersion.code == 1:
@@ -619,7 +626,7 @@ proc findVersion(repoPath: string, debug: bool, version: string,
     if forkExecWithoutOutput(gitCmd, "-C", repoPath, "checkout", commits.untested[middle]) == 0:
       let foundVersion = forkWaitRedirect(() => (block:
         if not dropPrivileges or dropPrivRedirect():
-          execRedirect(pkgLibDir & "/bisect", "source", repoPath & "/trunk", version, "true")
+          execRedirect(bisectCommand & @["source", repoPath / "trunk", version, "true"])
         else:
           quit(1)))
 
@@ -651,7 +658,7 @@ proc findVersion(repoPath: string, debug: bool, version: string,
     if forkExecWithoutOutput(gitCmd, "-C", repoPath, "checkout", allRevisions.output[i]) == 0:
       let foundVersion = forkWaitRedirect(() => (block:
         if not dropPrivileges or dropPrivRedirect():
-          execRedirect(pkgLibDir & "/bisect", "source", repoPath & "/trunk", version, "true")
+          execRedirect(bisectCommand & @["source", repoPath / "trunk", version, "true"])
         else:
           quit(1)))
       if foundVersion.code == 1:
@@ -782,7 +789,7 @@ proc obtainBuildPkgInfosInternal(config: Config, bases: seq[LookupBaseGroup],
               x
 
         let pkgInfosTable = pkgInfos.map(i => (i.rpc.name, i)).toTable
-        
+
         let foundPkgInfos = collect(newSeq):
           for y in pacmanTargetNames:
             for x in pkgInfosTable.opt(y):

--- a/src/config.nim
+++ b/src/config.nim
@@ -126,10 +126,10 @@ proc pacmanDbRel*(config: PacmanConfig): string =
   else:
     let root = config.pacmanRootRel
     let workRoot = if root == "/": "" else: root
-    workRoot & localStateDir & "/lib/pacman/"
+    workRoot & LocalStateDir & "/lib/pacman/"
 
 proc pacmanCacheRel*(config: PacmanConfig): string =
-  config.cacheRelOption.get(localStateDir & "/cache/pacman/pkg")
+  config.cacheRelOption.get(LocalStateDir & "/cache/pacman/pkg")
 
 proc simplifyConfigPath(path: string): string =
   if path.find("//") >= 0:
@@ -141,7 +141,7 @@ proc extendRel*(pathRel: string, sysroot: Option[string]): string =
   sysroot.map(s => (s & "/" & pathRel).simplifyConfigPath).get(pathRel)
 
 proc obtainConfig*(config: PacmanConfig): Config =
-  let (configTable, _) = readConfigFile(sysConfDir & "/pakku.conf")
+  let (configTable, _) = readConfigFile(SysConfDir & "/pakku.conf")
   let options = configTable.opt("options").map(t => t[]).get(initTable[string, string]())
 
   let root = config.pacmanRootRel.extendRel(config.sysrootOption)

--- a/src/feature/syncinstall.nim
+++ b/src/feature/syncinstall.nim
@@ -425,7 +425,7 @@ proc buildLoop(config: Config, pkgInfos: seq[PackageInfo], skipDeps: bool,
 
   let confFileEnv = getEnv("MAKEPKG_CONF")
   let confFile = if confFileEnv.len == 0:
-      sysConfDir & "/makepkg.conf"
+      SysConfDir & "/makepkg.conf"
     else:
       confFileEnv
 

--- a/src/feature/syncinstall.nim
+++ b/src/feature/syncinstall.nim
@@ -683,15 +683,15 @@ proc installGroupFromSources(config: Config, commonArgs: seq[Argument],
       let pacmanDatabaseParams = pacmanCmd & pacmanParams(config.color,
         commonArgs.keepOnlyOptions(commonOptions) & ("D", none(string), ArgumentType.short))
 
-      let installParams = config.sudoCommand & (pkgLibDir & "/install") &
-        cacheDir & $cacheUser & $cacheGroup &
-        $pacmanUpgradeParams.len & pacmanUpgradeParams &
-        $pacmanDatabaseParams.len & pacmanDatabaseParams &
-        (block:collect(newSeq):
-          for i in installWithReason:
-            for x in [i.name,i.file,i.mode]:
-              x
-        )
+      let installParams = block:
+        var p = config.sudoCommand
+        p.add helperToolCommand("install")
+        p.add [cacheDir, $cacheUser, $cacheGroup, $pacmanUpgradeParams.len]
+        p.add pacmanUpgradeParams
+        p.add $pacmanDatabaseParams.len
+        p.add pacmanDatabaseParams
+        for i in installWithReason: p.add [i.name, i.file, i.mode]
+        p
 
       let code = forkWait(() => execResult(installParams))
       if code != 0:

--- a/src/main.nim
+++ b/src/main.nim
@@ -201,13 +201,21 @@ proc handleHelp(operation: OperationType) =
         discard
 
 const
-  version = getEnv("PROG_VERSION")
-  copyright = getEnv("PROG_COPYRIGHT")
+  pakkuVersion {.strdefine.} = ""
+  pakkuCopyright {.strdefine.} = ""
+static:
+  doAssert pakkuVersion != "", "config.nims must define pakkuVersion"
+  doAssert pakkuCopyright != "", "config.nims must define pakkuCopyright"
+
 
 proc handleVersion(): int =
-  echo()
-  echo(' '.repeat(23), "Pakku v", version)
-  echo(' '.repeat(23), "Copyright (C) ", copyright)
+  const
+    indent = spaces(23)
+    prefix = "Copyright (C) "
+  echo("\n", indent, "Pakku v", pakkuVersion)
+  for line in pakkuCopyright.splitLines():
+    if line != "":
+      echo(indent, prefix, line)
   pacmanExec(noPrefix, false, ("V", none(string), ArgumentType.short))
 
 discard setlocale(LC_ALL, "")
@@ -232,7 +240,7 @@ let init = withErrorHandler(none(bool),
 
   let
     parsedArgs = splitArgs(
-      commandLineParams(), optionsWithParameter, 
+      commandLineParams(), optionsWithParameter,
       (operations.map(o => o.pair.long) & allOptions.map(o => o.pair.long))
       .deduplicate)
 

--- a/src/pacman.nim
+++ b/src/pacman.nim
@@ -379,7 +379,7 @@ proc obtainPacmanConfig*(args: seq[Argument]): PacmanConfig =
 
   let sysroot = args.filter(a => a.matchOption(%%%"sysroot")).optFirst.map(a => a.value).flatten
 
-  let configFileRel = getAll(%%%"config").optLast.get(sysConfDir & "/pacman.conf")
+  let configFileRel = getAll(%%%"config").optLast.get(SysConfDir & "/pacman.conf")
   let (configTable, wasError) = readConfigFile(configFileRel.extendRel(sysroot))
 
   let options = configTable.opt("options").map(t => t[]).get(initTable[string, string]())
@@ -433,7 +433,7 @@ proc obtainPacmanConfig*(args: seq[Argument]): PacmanConfig =
       else:
         var pgpKeyserver = none(string)
         var file: File
-        if file.open(gpgRel.get(sysConfDir & "/pacman.d/gnupg").extendRel(sysroot) & "/gpg.conf"):
+        if file.open(gpgRel.get(SysConfDir & "/pacman.d/gnupg").extendRel(sysroot) & "/gpg.conf"):
           try:
             while true:
               let line = file.readLine()

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -62,6 +62,26 @@ const
   pacmanCmd* = "/usr/bin/pacman"
   makepkgCmd* = "/usr/bin/makepkg"
 
+proc helperToolCommand*(tool: string): seq[string] =
+  ## Resolve a helper tool command.
+  ##
+  ## Prefer the installed helper symlink in `pkgLibDir`.
+  ## When pakku runs from a development environment, falls back
+  ## to the local `lib/tools` wrapper and passes the helper name as argv[1].
+  let installedTool = pkgLibDir / tool
+  if fileExists(installedTool):
+    return @[installedTool]
+
+  let appDir = getAppFilename().parentDir()
+  let fallbackTools = @[
+    appDir / "lib" / "tools",
+    appDir.parentDir() / "lib" / "tools"
+  ]
+  for toolsPath in fallbackTools:
+    if fileExists(toolsPath):
+      return @[toolsPath, tool]
+  @[installedTool]
+
 template haltError*(exitCode: int): untyped =
   var e: ref HaltError
   new(e)

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -42,10 +42,16 @@ proc cunsetenv*(name: cstring): cint
   {.importc: "unsetenv", header: "<stdlib.h>".}
 
 const
-  pkgLibDir* = getEnv("PROG_PKGLIBDIR")
-  localStateDir* = getEnv("PROG_LOCALSTATEDIR")
-  sysConfDir* = getEnv("PROG_SYSCONFDIR")
+  pakkuPrefix* {.strdefine.} = ""
+  LocalStateDir* {.strdefine.} = ""
+  SysConfDir* {.strdefine.} = ""
+static:
+  doAssert pakkuPrefix != "", "config.nims must define pakkuPrefix"
+  doAssert LocalStateDir != "", "config.nims must define LocalStateDir"
+  doAssert SysConfDir != "", "config.nims must define SysConfDir"
 
+const
+  pkgLibDir* = pakkuPrefix / "/lib/pakku"
   bashCmd* = "/bin/bash"
   suCmd* = "/usr/bin/su"
   sudoCmd* = "/usr/bin/sudo"


### PR DESCRIPTION
I have nothing to say against Makefiles, but I think this is more idiomatic for a nim project.

- Uses config.nims as the canonical source of defaults.
- Moves pakku metadata of Makefile/env injection and into Nim defines,  so direct nim builds are now populated properly and share the same  configuration model with the Makefile.
- Keeps only the packaging-relevant overrides in Makefile: the release  version derived from git and PREFIX used by Arch PKGBUILDs.
- Adds stripping and `-flto` to release build settings
- Adds `nim build` task for dev speed
- Fixes `-V` formatting to support multiline copyright text.
- Adds `testmakefile` task that checks the Makefile in the  ways the project actually depends on.
- Fixes completion generation explicitly fire via `/bin/bash`  to not rely on the executable bit.
- Fixes Makefile install/uninstall logging to show real paths by including  `DESTDIR`.