### PR TITLE
makepkg config file resolution

### DIFF
--- a/src/common.nim
+++ b/src/common.nim
@@ -1,5 +1,7 @@
 import
-  options, os, osproc, posix, sequtils, sets, strutils, sugar, tables,
+  std/[options, os, osproc, posix, sequtils, sets, strutils, sugar, tables,
+    paths, files
+  ],
   args, config, format, lists, package, pacman, utils,
   "wrapper/alpm"
 when not declared(system.stdout): import std/syncio
@@ -63,6 +65,31 @@ proc checkAndRefreshUpgradeInternal(
     (code, callArgs)
   else:
     (0, args)
+
+proc resolveMakepkgConf*(): tuple[path: Option[Path], error: string] =
+  let envConf = getEnv("MAKEPKG_CONF")
+  if envConf.len > 0:
+    if fileExists(envConf):
+      return (some(Path(envConf)), "")
+    else:
+      return (none(Path), tr"MAKEPKG_CONF points to missing file '$#'" % [envConf])
+
+  let homeDir = getEnv("HOME")
+  let userConfigDir = getUserConfigDir()
+
+  var candidates = newSeq[Path]()
+  if userConfigDir.isSome:
+    candidates.add userConfigDir.unsafeGet / Path("pacman") / Path("makepkg.conf")
+  if homeDir.len > 0:
+    candidates.add Path(homeDir / ".makepkg.conf")
+  candidates.add Path(SysConfDir / "makepkg.conf")
+
+  for path in candidates:
+    if fileExists(path):
+      # TODO: Merge makepkg.conf drop-ins here when pakku starts honoring them.
+      return (some(path), "")
+
+  (none(Path), tr"failed to find makepkg config file")
 
 template checkAndRefreshUpgrade*(sudoPrefix: seq[string], color: bool, args: seq[Argument]):
   tuple[code: int, args: seq[Argument]] =

--- a/src/feature/syncinstall.nim
+++ b/src/feature/syncinstall.nim
@@ -423,11 +423,11 @@ proc buildLoop(config: Config, pkgInfos: seq[PackageInfo], skipDeps: bool,
   if contains(pkgInfos[0].rpc.gitUrl, "https://github.com/archlinux/") or pkgInfos[0].rpc.gitUrl == "https://gitea.artixlinux.org/packages":
     buildPath = buildPath & "trunk/"
 
-  let confFileEnv = getEnv("MAKEPKG_CONF")
-  let confFile = if confFileEnv.len == 0:
-      SysConfDir & "/makepkg.conf"
-    else:
-      confFileEnv
+  let (confFileOpt, confError) = resolveMakepkgConf()
+  if confFileOpt.isNone and confError.len > 0:
+    printError(config.color, confError)
+    return (none(BuildResult), 1, false)
+  let confFile = confFileOpt.unsafeGet.string
 
   let workConfFile = config.tmpRootInitial & "/makepkg.conf"
 

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -3,6 +3,7 @@ import
     hashes,
     options,
     os,
+    paths,
     posix,
     sequtils,
     strutils,
@@ -387,6 +388,17 @@ proc dropPrivileges*(): bool =
 proc checkExec(file: string): bool =
   var statv: Stat
   stat(file, statv) == 0 and (statv.st_mode.cint and S_IXUSR) == S_IXUSR
+
+proc getUserConfigDir*(): Option[Path] =
+  let xdgConfigHome = getEnv("XDG_CONFIG_HOME")
+  if xdgConfigHome.len > 0:
+    some(Path(xdgConfigHome))
+  else:
+    let homeDir = getEnv("HOME")
+    if homeDir.len > 0:
+      some(Path(homeDir / ".config"))
+    else:
+      none(Path)
 
 proc getSudoPrefix*(preferred: Option[string]): seq[string] =
   ## Get the prefix to be used for escalated priviliges. The search order is


### PR DESCRIPTION
I'm planning to add some switches to be able to better align pakku with my local makepkg settings, here's the first step.

Now resolves the base makepkg.conf in this order:

- MAKEPKG_CONF
- $XDG_CONFIG_HOME/pacman/makepkg.conf
- ~/.makepkg.conf
- /etc/makepkg.conf

If MAKEPKG_CONF is set but points to a missing file, pakku now errors explicitly instead of silently falling back.

The resolver in `common` has TODO at the point where makepkg's drop-in dir merging should be added.