### PR TITLE
Add numeric skip selection for AUR upgrades

### DIFF
--- a/src/feature/syncinstall.nim
+++ b/src/feature/syncinstall.nim
@@ -1028,7 +1028,7 @@ proc checkNeeded(installed: Table[string, Installed],
 
 proc obtainAurPackageInfos(config: Config, rpcInfos: seq[RpcPackageInfo],
   rpcAurTargets: seq[FullPackageTarget], installed: Table[string, Installed],
-  printMode: bool, needed: bool, upgradeCount: int): (seq[PackageInfo], seq[PackageInfo],
+  printMode: bool, noconfirm: bool, needed: bool, upgradeCount: int): (seq[PackageInfo], seq[PackageInfo],
   seq[string], seq[Installed], seq[LocalIsNewer], seq[string]) =
   let targetRpcInfoPairs: seq[tuple[rpcInfo: RpcPackageInfo, upgradeable: bool]] =
     rpcAurTargets.map(f => f.rpcInfo.get).map(i => (i, installed
@@ -1062,9 +1062,43 @@ proc obtainAurPackageInfos(config: Config, rpcInfos: seq[RpcPackageInfo],
           (res.needed, none(LocalIsNewer))
       (i, newNeeded, localIsNewer)))
 
+  let selectedUpgradeRpcInfos = if printMode or noconfirm: (block:
+      upgradeStructs.filter(p => p.needed).map(p => p.rpcInfo))
+    else: (block:
+      let neededUpgradeStructs = upgradeStructs.filter(p => p.needed)
+
+      if neededUpgradeStructs.len == 0:
+        @[]
+      else:
+        printColon(config.color, tr"Available AUR upgrades")
+        echo()
+        let numberWidth = max(($neededUpgradeStructs.len).len, 2)
+        for index, upgrade in neededUpgradeStructs:
+          let installedVersion = installed[upgrade.rpcInfo.name].version
+          let number = align($(index + 1), numberWidth, ' ')
+          echo(number, ") ", config.aurRepo, "/", upgrade.rpcInfo.name,
+            " ", installedVersion, " -> ", upgrade.rpcInfo.version)
+        echo()
+
+        proc inputLoop(): seq[RpcPackageInfo] =
+          while true:
+            let input = printColonUserInput(config.color,
+              tr"Packages to skip (syntax: 1, 3-5, 7 11)" & ":", noconfirm, "", "")
+            let intervalsOpt = parseNumberIntervals(input, neededUpgradeStructs.len)
+            if intervalsOpt.isSome:
+              let intervals = intervalsOpt.unsafeGet
+              return block:
+                var filtered: seq[RpcPackageInfo]
+                for idx, i in neededUpgradeStructs:
+                  if not intervals.anyIt(idx + 1 in it):
+                    filtered.add i.rpcInfo
+                filtered
+            printError(config.color, tr"invalid package selection")
+        inputLoop())
+
   let targetRpcInfos = targetRpcInfoPairs
     .filter(i => not needed or i.upgradeable).map(i => i.rpcInfo)
-  let upgradeRpcInfos = upgradeStructs.filter(p => p.needed).map(p => p.rpcInfo)
+  let upgradeRpcInfos = selectedUpgradeRpcInfos
   let fullRpcInfos = targetRpcInfos & upgradeRpcInfos
 
   let (update, terminate) = createCloneProgress(config, fullRpcInfos.len, true, printMode)
@@ -1179,7 +1213,7 @@ proc resolveBuildTargets(config: Config, syncTargets: seq[SyncPackageTarget],
 
   let (aurPkgInfos, additionalPkgInfos, aurPaths, upToDateNeeded, localIsNewerSeq, aperrors) =
     obtainAurPackageInfos(config, rpcInfos, rpcAurTargets, installedTable,
-      printMode, needed, upgradeCount)
+      printMode, noconfirm, needed, upgradeCount)
   for e in aperrors: printError(config.color, e)
 
   let upToDateNeededTable: Table[string, PackageReference] = upToDateNeeded.map(i => (i.name,

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -1,5 +1,6 @@
 import
   std/[
+    algorithm,
     hashes,
     options,
     os,
@@ -109,6 +110,50 @@ template orElse*[T, R](opt1: Option[T], opt2: Option[R]): Option[R] =
 
 template hash*[T](opt: Option[T]): int =
   opt.map(hash).get(0)
+
+proc parseNumberIntervals*(input: string; maxValue: Positive
+  ): Option[seq[Slice[int]]] =
+  type Interval = Slice[int]
+  if maxValue < 1: return some(newSeq[Interval]())
+  let normalized = input.multiReplace(({'\t', '\n', '\r', ','}, ' '))
+  let tokens = normalized.splitWhitespace()
+  if tokens.len == 0: return some(newSeq[Interval]())
+
+  var intervals = newSeq[Interval](tokens.len)
+  for token in tokens:
+    let dash = token.find('-')
+    if dash < 0: # single value
+      try:
+        let v = token.parseUint()
+        if v notin 1.uint..maxValue.uint:
+          return none(seq[Interval])
+        intervals.add (v.int..v.int)
+      except ValueError:
+        return none(seq[Interval])
+    else: # range
+      if dash == 0 or dash == token.high or token.find('-', dash + 1) >= 0:
+        return none(seq[Interval])
+      try:
+        let a = token[0..(dash-1)].parseUint()
+        let b = token[(dash+1)..^1].parseUint()
+        if a < 1.uint or b < 1.uint or a > b or b > maxValue.uint:
+          return none(seq[Interval])
+        intervals.add(a.int..b.int)
+      except ValueError: return none(seq[Interval])
+  intervals.sort(proc(x, y: Interval): int = cmp(y.a, x.a)) # by starts, reversed
+
+  var merged: seq[Interval] = @[]
+  while intervals.len > 0:
+    let iv = intervals.pop()
+    if merged.len == 0: merged.add iv
+    else:
+      var last = merged[^1]
+      if iv.a <= last.b + 1:
+        if iv.b > last.b:
+          last.b = iv.b
+        merged[^1] = last
+      else: merged.add iv
+  some(merged)
 
 proc opt*[K, V](table: Table[K, V], key: K): Option[V] =
   if table.hasKey(key): some(table[key]) else: none(V)


### PR DESCRIPTION
Adds numeric skip selection for AUR upgrades

```cmd
 1) aur/foo 2025.10-3 -> 2026.03-3
 2) aur/baz 45.0.7632 -> 146.0.7680
 3) aur/baz 1.19.18-1 -> 1.19.22-1

:: Packages to skip (syntax: 1, 3-5, 7 11):
```