### PR TITLE
build: Makefile always builds in release mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ endif
 NIM_CACHE_DIR = nimcache
 
 NIM_OPTIONS = \
+	-d:release \
 	-d:pakkuVersion="${RVERSION}" \
 	-d:pakkuPrefix="${PREFIX}"
 

--- a/config.nims
+++ b/config.nims
@@ -3,8 +3,6 @@ const
   Prefix        = "/usr/local"
   SysConfDir    = "/etc"
   LocalStateDir = "/var"
-  BuildTarget   = "release"
-  BuildOptimize = "size"
   Copyright     = """2018-2019 kitsunyan
 2020-2023 zqqw"""
 
@@ -16,11 +14,10 @@ switch("define", "pakkuCopyright=" & Copyright)
 
 --mm:arc
 --threads:off
---define:buildTarget
 #--define:nimPreviewSlimSystem
 
 when defined(release):
-  switch("opt", BuildOptimize)
+  --opt:"size"
   --passL:"-s"
   --passC:"-s"
   --passL:"-flto"


### PR DESCRIPTION
This fixes the regression I introduced while moving build settings to config.nims.
Now Make always builds in release mode.

For development use `nim build` which doesn't set the release flag but propagates custom ones: `nim -d:release build` builds in release mode without Make.

I think it wouldn't hurt to move the [build instructions](wiki/Building-and-modifying-pakku)  to the readme file so they live with the code. If it TMI it could be hidden with `<details>`+`<summary>`.