### PR TITLE
build: unify version handling, auto `-dev`, opt-in tag-checked releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-VERSION = 0.16
 DIST_MODE = false
 
 MAN_PAGES = \
@@ -43,12 +42,19 @@ MANDIR = ${PREFIX}/share/man
 LOCALSTATEDIR = /var
 SYSCONFDIR = /etc
 
-ifneq ($(wildcard .git),)
-RVERSION = $(shell (git describe --tags 2> /dev/null || echo v${VERSION}) | \
-tail -c +2 | head -1)
-else
-RVERSION = ${VERSION}
-endif
+# Version authority:
+#   config.nims:
+#     Version - actual manually maintained release number.
+#     EffectiveVersion - adds "-dev" for non-release builds.
+#   RVERSION:
+#     `(git describe || CFG_VERSION)` - git tags win in clones and
+#     AUR `-git` builds, the constant fallback covers no-git builds (tarballs).
+#
+# Make injects RVERSION to compile options directly and overrides config.nims
+# so release builds and man generation carry the accurate git-aware version.
+CFG_VERSION = $(shell sed -n 's/^[[:space:]]*Version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' config.nims)
+RVERSION = $(shell (git describe --tags 2> /dev/null || echo "$(CFG_VERSION)") \
+             | sed 's/^v//')
 
 NIM_CACHE_DIR = nimcache
 
@@ -63,7 +69,7 @@ ASCIIDOC_OPTIONS = \
 	-a mansource='Pakku' \
 	-a manversion="${RVERSION}"
 
-.PHONY: all clean install uninstall distcheck
+.PHONY: all clean install uninstall distcheck release releasecheck
 
 all: \
 	${TARGETS} \
@@ -159,7 +165,6 @@ distcheck:
 	@for f in ${DIST}; do cp -d --parents $$f 'pakku-${RVERSION}'; done
 
 	@sed -i 'pakku-${RVERSION}/Makefile' \
-	-e 's/^VERSION =.*/VERSION = ${RVERSION}/' \
 	-e 's/^DIST_MODE =.*/DIST_MODE = true/'
 
 	@(cd 'pakku-${RVERSION}' && \
@@ -175,3 +180,17 @@ distcheck:
 	${EXTRA_DIST:%='pakku-${RVERSION}'/%}
 
 	@rm -rf 'pakku-${RVERSION}'
+
+# Explicit ceonvenience path
+release: releasecheck
+	$(MAKE) distcheck
+
+# Opt-in check version/git-tag de-sync before release:
+# Require HEAD to sit exactly on v${CFG_VERSION} - version read from config.nims
+releasecheck:
+	@{ test -n "$(CFG_VERSION)" || { echo "releasecheck: Version empty in config.nims"; exit 1; }; \
+	   desc="$$(git describe --tags --exact-match 2>/dev/null)"; \
+	   test -n "$$desc" || { echo "releasecheck: HEAD is not exactly on a tag"; exit 1; }; \
+	   test "$$desc" = "v${CFG_VERSION}" || { echo "releasecheck: tag $$desc != v${CFG_VERSION} (config.nims Version)"; exit 1; }; \
+	   test -z "$$(git status --porcelain)" || { echo "releasecheck: tree has uncommitted changes"; exit 1; }; }
+	@echo "releasecheck: on v${CFG_VERSION}, tree clean"

--- a/config.nims
+++ b/config.nims
@@ -1,12 +1,14 @@
 const
-  Version       = "0.16-dev"
+  Version       = "0.17" # also read by make unless it's building from a git-tagged commit
+  EffectiveVersion = when defined(release): Version else: Version & "-dev"
   Prefix        = "/usr/local"
   SysConfDir    = "/etc"
   LocalStateDir = "/var"
   Copyright     = """2018-2019 kitsunyan
-2020-2023 zqqw"""
+2020-2026 zqqw
+2026 ZoomRmc"""
 
-switch("define", "pakkuVersion=" & Version)
+switch("define", "pakkuVersion=" & EffectiveVersion)
 switch("define", "pakkuPrefix=" & Prefix)
 switch("define", "SysConfDir=" & SysConfDir)
 switch("define", "LocalStateDir=" & LocalStateDir)


### PR DESCRIPTION
The compiled-in version was inconsistently maintained in three places:
- git tag (real release marker)
- Makefile `VERSION` (lagging)
- `config.nims` `Version` for debug and no-make builds, needs sync with Makefile and manual suffix addition.

Even though `v0.17` tag is three years old it never made it into the Makefile. Moreover, precedence between `config.nims` and the Makefile silently relies on compiler's last-option-wins behaviour.

Now:

1. `config.nims` carries the single manually-maintained bare release number.

  - Direct nim release builds get the bare number. This is open for debate as any build with `-d:release` gets the same version, regardless of actual source commit. Using this define as a release signal is simple, though.
  - Development/debug build runs (without `-d:release`) get `-dev` automatically.
  - Makefile derives the number from the git tag when available, or falls back to reading  `config.nims` so builds from tarballs or shallow clones still work.

2. Adds `make releasecheck` - a new **opt-in** release check so releasing from a tree whose version drifted from the tag is now a hard error, requires HEAD to sit exactly on `v${CFG_VERSION}`, a clean, and a non-empty `Version`. Could be used later in CI, adding by default will break PKGBUILDs.

## Note for AUR maintainers:

- Drop `cut` from `pkgver`: `git describe --tags | sed -e 's+-+.r+' -e 's/^v//' | tr - .`
- The dead `addargs=(NIM_TARGET='debug' NIM_OPTIMIZE='none')` should be dropped, removed earlier. The `build` becomes simply:
  ```PKGBUILD
  build() {
    cd "$srcdir/$pkgname-$pkgver"
    make NIM_CACHE_DIR='../nimcache' PREFIX='/usr'
  }
   ```
